### PR TITLE
Updated image prefappacr.azurecr.io/service/test-repo-rundagger:d0c66e1_default for tenant: prefapp in application: test-repo-rundagger and env: dev

### DIFF
--- a/prefapp/test-repo-rundagger/dev/images.yaml
+++ b/prefapp/test-repo-rundagger/dev/images.yaml
@@ -1,2 +1,2 @@
 controller:
-  image: ghcr.io/prefapp/gitops-k8s:6c1da5e_full
+  image: prefappacr.azurecr.io/service/test-repo-rundagger:d0c66e1_default


### PR DESCRIPTION
Updated image from: ghcr.io/prefapp/gitops-k8s:6c1da5e_full to: prefappacr.azurecr.io/service/test-repo-rundagger:d0c66e1_default in services: [
  "controller"
]
                          for tenant: prefapp in application: test-repo-rundagger at environment: dev